### PR TITLE
fix(index): materialIconのimportを修正

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -40,7 +40,7 @@
     <app-root></app-root>
     <style>
       @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+JP:wght@400;500&display=swap');
-      @import url('https://fonts.googleapis.com/icon?family=Material+Icons&display=swap');
+      @import url('https://fonts.googleapis.com/icon?family=Material+Icons');
     </style>
     <noscript
       >Please enable JavaScript to continue using this application.</noscript


### PR DESCRIPTION
fix #163 