### PR TITLE
feat: add view count display for article authors only

### DIFF
--- a/src/app/components/article-card/article-card.component.html
+++ b/src/app/components/article-card/article-card.component.html
@@ -42,6 +42,10 @@
             <span>{{ likeCount }}</span>
           </ng-template>
         </div>
+        <div class="card__view-count" *ngIf="article.author.uid === authService.uid">
+          <mat-icon aria-hidden="true" fontIcon="visibility"></mat-icon>
+          <span>{{ viewCount$ | async }}</span>
+        </div>
         <div class="card__updated-date">
           <mat-icon aria-hidden="true" fontIcon="update"></mat-icon>
           <span>{{

--- a/src/app/components/article-card/article-card.component.ts
+++ b/src/app/components/article-card/article-card.component.ts
@@ -3,8 +3,10 @@ import { ArticleWithAuthor } from '@interfaces/article-with-author';
 import { take } from 'rxjs/operators';
 import { AuthService } from 'src/app/services/auth.service';
 import { LikeService } from 'src/app/services/like.service';
+import { ViewCountService } from 'src/app/services/view-count.service';
+import { Observable } from 'rxjs';
 import { MatIconModule } from '@angular/material/icon';
-import { NgIf, DatePipe } from '@angular/common';
+import { NgIf, DatePipe, AsyncPipe } from '@angular/common';
 import { RouterLink } from '@angular/router';
 
 @Component({
@@ -12,21 +14,24 @@ import { RouterLink } from '@angular/router';
   templateUrl: './article-card.component.html',
   styleUrls: ['./article-card.component.scss'],
   standalone: true,
-  imports: [RouterLink, NgIf, MatIconModule, DatePipe],
+  imports: [RouterLink, NgIf, MatIconModule, DatePipe, AsyncPipe],
 })
 export class ArticleCardComponent implements OnInit {
   @Input() article: ArticleWithAuthor;
   isLiked: boolean;
   likeCount: number;
+  viewCount$: Observable<number>;
 
   constructor(
     private likeService: LikeService,
-    private authService: AuthService
+    private authService: AuthService,
+    private viewCountService: ViewCountService
   ) {}
 
   ngOnInit() {
     this.likeCount = this.article.likeCount;
     this.updateLikeCount();
+    this.viewCount$ = this.viewCountService.getViewCount(this.article.articleId);
   }
 
   updateLikeCount() {

--- a/src/app/pages/article-detail/article-detail.component.html
+++ b/src/app/pages/article-detail/article-detail.component.html
@@ -89,6 +89,10 @@
           <p class="article-header__updated-date">
             {{ article.updatedAt.toDate() | date : 'yyyy年MM月dd日' }}更新
           </p>
+          <p class="article-header__view-count" *ngIf="article.author.uid === authService.uid">
+            <mat-icon aria-hidden="true" fontIcon="visibility"></mat-icon>
+            <span>{{ viewCount$ | async }}回表示</span>
+          </p>
           <app-article-edit-buttons
             class="article-header__actions"
             *ngIf="article.author.uid === authService.uid"

--- a/src/app/pages/article-detail/article-detail.component.ts
+++ b/src/app/pages/article-detail/article-detail.component.ts
@@ -87,6 +87,7 @@ export default class ArticleDetailComponent implements OnDestroy {
       }
       if (article) {
         this.initLikeStatus(article);
+        this.initViewCount(article);
         this.seoService.updateTitleAndMeta({
           title: `${article.title}`,
           description: article.text,
@@ -108,6 +109,7 @@ export default class ArticleDetailComponent implements OnDestroy {
 
   likeCount: number;
   isLiked: boolean;
+  viewCount$: Observable<number>;
 
   projectURL = environment.hostingURL;
   path: string = this.location.path();
@@ -154,6 +156,10 @@ export default class ArticleDetailComponent implements OnDestroy {
       .then((result) => {
         this.isLiked = result;
       });
+  }
+
+  private initViewCount(article: ArticleWithAuthor) {
+    this.viewCount$ = this.viewCountService.getViewCount(article.articleId);
   }
 
   @HostListener('window:scroll', ['$event'])

--- a/src/app/services/view-count.service.ts
+++ b/src/app/services/view-count.service.ts
@@ -1,6 +1,10 @@
 import { inject, Injectable } from '@angular/core';
 import { FirebaseService } from './firebase.service';
 import { httpsCallable } from '@angular/fire/functions';
+import { doc, docData } from '@angular/fire/firestore';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { ArticleViewCount } from '@interfaces/article-view-count';
 
 @Injectable({
   providedIn: 'root',
@@ -14,5 +18,12 @@ export class ViewCountService {
       'countUpArticleView'
     );
     callable(sendData);
+  }
+
+  getViewCount(articleId: string): Observable<number> {
+    const viewCountDocRef = doc(this.firebaseService.firestore, `viewCount/${articleId}`);
+    return docData(viewCountDocRef).pipe(
+      map((data: ArticleViewCount) => data?.viewCount as number || 0)
+    );
   }
 }

--- a/src/test/service.stub.ts
+++ b/src/test/service.stub.ts
@@ -75,6 +75,9 @@ export const ViewCountServiceStub = {
   countUpArticleView: jasmine
     .createSpy('countUpArticleView')
     .and.returnValue(undefined),
+  getViewCount: jasmine
+    .createSpy('getViewCount')
+    .and.returnValue(new BehaviorSubject(0)),
 };
 
 export class ActivatedRouteStub {


### PR DESCRIPTION
Add view count display functionality that shows article view counts only to the article author.

## Changes
- Add `getViewCount()` method to ViewCountService to fetch data from Firestore
- Display view counts on article detail page (author only)
- Display view counts on article cards (author only)
- Use condition: `article.author.uid === authService.uid`
- Update test stubs for compatibility

Closes #181

Generated with [Claude Code](https://claude.ai/code)