### PR TITLE
fix: `getViewCount`を`getDoc`へ変更


### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(npm run test:*)",
       "Bash(grep:*)",
-      "Bash(npm run lint)"
+      "Bash(npm run lint)",
+      "Bash(npm run build:*)"
     ],
     "deny": []
   }

--- a/src/app/services/view-count.service.ts
+++ b/src/app/services/view-count.service.ts
@@ -1,8 +1,8 @@
 import { inject, Injectable } from '@angular/core';
 import { FirebaseService } from './firebase.service';
 import { httpsCallable } from '@angular/fire/functions';
-import { doc, docData } from '@angular/fire/firestore';
-import { Observable } from 'rxjs';
+import { doc, getDoc } from '@angular/fire/firestore/lite';
+import { from, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ArticleViewCount } from '@interfaces/article-view-count';
 
@@ -22,10 +22,13 @@ export class ViewCountService {
 
   getViewCount(articleId: string): Observable<number> {
     const viewCountDocRef = doc(this.firebaseService.firestore, `viewCount/${articleId}`);
-    return docData(viewCountDocRef).pipe(
-      map((data: any) => {
-        const viewCountData = data as ArticleViewCount;
-        return typeof viewCountData?.viewCount === 'number' ? viewCountData.viewCount : 0;
+    return from(getDoc(viewCountDocRef)).pipe(
+      map((docSnap) => {
+        if (!docSnap.exists()) {
+          return 0;
+        }
+        const viewCountData = docSnap.data() as ArticleViewCount;
+        return typeof viewCountData.viewCount === 'number' ? viewCountData.viewCount : 0;
       })
     );
   }


### PR DESCRIPTION
### **User description**
## 概要
  記事詳細ページが表示されない問題と、閲覧数表示のバグを修正しました。

  ## 問題の詳細
  - Firestore APIの不整合により、記事詳細ページでランタイムエラーが発生
  - `@angular/fire/firestore`（リアルタイム版）と`@angular/fire/firestore/lite`（軽量版）の混在が原因

  ## 変更内容
  - ✅ `view-count.service.ts`のインポートを`firestore/lite`に統一
  - ✅ `docData`（リアルタイムリスナー）から`getDoc`（一回限りの読み込み）に変更
  - ✅ ドキュメントが存在しない場合の処理を改善（初回表示時も0を返すように）
  - ✅ 型安全性を向上（`any`型を排除）

  ## テスト方法
  1. 記事詳細ページにアクセスして正常に表示されることを確認
  2. 記事作成者として閲覧数が表示されることを確認
  3. 初回アクセス時も「0回表示」と正しく表示されることを確認
  4. コンソールにエラーが出ないことを確認

  ## 影響範囲
  - 記事詳細ページ（`/articles/{username}/{articleId}`）
  - 閲覧数表示機能（記事作成者のみ表示）


___

### **PR Type**
Bug fix


___

### **Description**
- `getViewCount`を`getDoc`へ変更

- Firestore APIを-lite版に統一

- ドキュメント未存在時に0返却

- Promiseを`from`でObservable化


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>view-count.service.ts</strong><dd><code>firestore/lite版`getDoc`導入への移行</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/services/view-count.service.ts

<li><code>@angular/fire/firestore</code>から<code>/firestore/lite</code>へ変更<br> <li> <code>docData</code>リアルタイムリスナーを<code>getDoc</code>へ移行<br> <li> <code>from</code>でPromiseをObservable化<br> <li> ドキュメント未存在時に0返却処理追加


</details>


  </td>
  <td><a href="https://github.com/komura-c/MusiL/pull/350/files#diff-20cf3ff49e1df859c473abe526c10eaac65fcda67775f47db45f6446e521fa6f">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>