### PR TITLE
feat: 記事作成者が閲覧数にアクセスできるようFirestoreルールを追

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,7 +3,8 @@
     "allow": [
       "Bash(npm run test:*)",
       "Bash(grep:*)",
-      "Bash(npm run lint)"
+      "Bash(npm run lint)",
+      "Bash(npm run build:*)"
     ],
     "deny": []
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -23,5 +23,9 @@ service cloud.firestore {
         allow write: if request.auth.uid == userId;
       }
     }
+    match /viewCount/{articleId} {
+      allow read: if request.auth != null && request.auth.uid == resource.data.uid;
+      allow write: if false;
+    }
   }
 }

--- a/src/app/services/view-count.service.ts
+++ b/src/app/services/view-count.service.ts
@@ -1,8 +1,8 @@
 import { inject, Injectable } from '@angular/core';
 import { FirebaseService } from './firebase.service';
 import { httpsCallable } from '@angular/fire/functions';
-import { doc, docData } from '@angular/fire/firestore';
-import { Observable } from 'rxjs';
+import { doc, getDoc } from '@angular/fire/firestore/lite';
+import { from, Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { ArticleViewCount } from '@interfaces/article-view-count';
 
@@ -22,10 +22,13 @@ export class ViewCountService {
 
   getViewCount(articleId: string): Observable<number> {
     const viewCountDocRef = doc(this.firebaseService.firestore, `viewCount/${articleId}`);
-    return docData(viewCountDocRef).pipe(
-      map((data: any) => {
-        const viewCountData = data as ArticleViewCount;
-        return typeof viewCountData?.viewCount === 'number' ? viewCountData.viewCount : 0;
+    return from(getDoc(viewCountDocRef)).pipe(
+      map((docSnap) => {
+        if (!docSnap.exists()) {
+          return 0;
+        }
+        const viewCountData = docSnap.data() as ArticleViewCount;
+        return typeof viewCountData.viewCount === 'number' ? viewCountData.viewCount : 0;
       })
     );
   }


### PR DESCRIPTION
## 概要
  記事作成者が自分の記事の閲覧数データにアクセスできるよう、Firestoreセキュリティルールを追加しました
  。

  ## 背景
  - 現在、`viewCount`コレクションにセキュリティルールが定義されていない
  - フロントエンドから閲覧数データを取得する際にアクセス権限エラーが発生する可能性がある

  ## 変更内容
  ### Firestoreルールに`viewCount`コレクションのルールを追加
  ```javascript
  match /viewCount/{articleId} {
    allow read: if request.auth != null && request.auth.uid == resource.data.uid;
    allow write: if false;
  }

  ルールの詳細

  - 読み取り権限: 認証済みユーザーかつ記事作成者のみアクセス可能
    - request.auth != null: ユーザーが認証されている
    - request.auth.uid == resource.data.uid: リクエストユーザーが記事作成者と一致
  - 書き込み権限: 無効化（Cloud Functionsからのみ更新）

  影響範囲

  - 記事詳細ページの閲覧数表示機能（記事作成者のみ）
  - view-count.service.tsからのデータ取得

  テスト方法

  1. Firebase エミュレータでルールをテスト
  2. 記事作成者として自分の記事の閲覧数が表示されることを確認
  3. 他のユーザーとして他人の記事の閲覧数にアクセスできないことを確認

  関連PR

  - #350 （閲覧数表示のバグ修正）

  🤖 Generated with https://claude.ai/code

  コミットは正常にプッシュされました。上記のリンクとテンプレートを使用してPRを作成してください。