### PR TITLE
fix: ボット判定ロジックを配列とsomeで簡潔化


### DIFF
--- a/functions/src/render.function.ts
+++ b/functions/src/render.function.ts
@@ -62,21 +62,23 @@ const server = async (req: any, res: any) => {
   res.set('Cache-Control', 'public, max-age=259200, s-maxage=172800');
 
   const userAgent: string = req.headers['user-agent'].toLowerCase();
-  const isBot: boolean =
-    userAgent.includes('googlebot') ||
-    userAgent.includes('developers.google.com')
-      ? true
-      : false ||
-        userAgent.includes('twitterbot') ||
-        userAgent.includes('facebookexternalhit') ||
-        userAgent.includes('yahoou') ||
-        userAgent.includes('bingbot') ||
-        userAgent.includes('baiduspider') ||
-        userAgent.includes('yandex') ||
-        userAgent.includes('yeti') ||
-        userAgent.includes('yodaobot') ||
-        userAgent.includes('gigabot') ||
-        userAgent.includes('ia_archiver');
+  const botKeywords = [
+    'googlebot',
+    'developers.google.com',
+    'twitterbot',
+    'facebookexternalhit',
+    'yahoou',
+    'bingbot',
+    'baiduspider',
+    'yandex',
+    'yeti',
+    'yodaobot',
+    'gigabot',
+    'ia_archiver',
+  ];
+  const isBot: boolean = botKeywords.some((keyword) =>
+    userAgent.includes(keyword)
+  );
   if (!isBot) {
     return res.status(200).send(file);
   }


### PR DESCRIPTION
### **User description**
## Summary
- Bot 判定ロジックを簡潔化

## Testing
- `npm test` *(fails: ng コマンドが見つからないため)*

------
https://chatgpt.com/codex/tasks/task_e_683fe4e2cc588322844260039c68462a


___

### **PR Type**
Bug fix


___

### **Description**
- ボット判定ロジックを配列化し簡潔化

- キーワード一覧を`botKeywords`に集約

- `some`メソッドでisBot評価

- 重複条件式を削除


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>render.function.ts</strong><dd><code>ボット判定ロジックの配列化リファクタリング</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

functions/src/render.function.ts

- キーワード一覧を`botKeywords`配列に統合
- `some`でbot判定処理を簡潔化
- 古い条件式や三項演算子を削除


</details>


  </td>
  <td><a href="https://github.com/komura-c/MusiL/pull/352/files#diff-ae9439e0419fa2802d1d0407c86de3632b3e4f829a2ba45c9a4ae6d244295f6d">+17/-15</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>