### PR TITLE
fix(ci): remove explicit pnpm version conflict

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: update node
         uses: actions/setup-node@v4

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 10
 
       - name: update node
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
deploy が `ERR_PNPM_BAD_PM_VERSION` で失敗していた問題の修正。

`pnpm/action-setup@v4` の `version: 10` 入力と `package.json` の `packageManager: pnpm@10.30.3` が両指定されていると衝突するため、action 側の version を削除し packageManager フィールドを信頼源とする。

## Test plan
- [ ] `dev` ワークフローが緑になる
- [ ] `prod` ワークフロー（タグ push 時）が緑になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)