### PR TITLE
fix(ci): build functions in workflow instead of firebase predeploy

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -45,6 +45,10 @@ jobs:
         working-directory: functions
         run: pnpm lint
 
+      - name: build functions
+        working-directory: functions
+        run: pnpm build
+
       # TODO: テストが整ったら入れる
       # - name: test
       #   run: pnpm test

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -45,6 +45,10 @@ jobs:
         working-directory: functions
         run: pnpm lint
 
+      - name: build functions
+        working-directory: functions
+        run: pnpm build
+
       # TODO: テストが整ったら入れる
       # - name: test
       #   run: pnpm test

--- a/firebase.json
+++ b/firebase.json
@@ -22,7 +22,6 @@
     "indexes": "firestore.indexes.json"
   },
   "functions": {
-    "predeploy": ["pnpm --dir \"$RESOURCE_DIR\" build"],
     "source": "functions"
   },
   "storage": {


### PR DESCRIPTION
## Summary
dev / prod デプロイで `functions predeploy error: Command terminated with non-zero exit code 127` (pnpm: not found) が発生していた問題の修正。

`w9jds/firebase-action` の Docker コンテナには npm しか入っていないため、firebase.json の predeploy で `pnpm --dir` を呼ぶとエラーになる。

## Changes
- `firebase.json` から `functions.predeploy` を削除
- `dev.yml` / `prod.yml` に `build functions` ステップ (`pnpm build`) を deploy 前に追加。pnpm 環境の host runner で functions/lib を生成し、コンテナへはビルド済み成果物を渡す

## Test plan
- [ ] dev ワークフローが緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)