### PR TITLE
fix(ci): pass --force to firebase deploy

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -56,7 +56,7 @@ jobs:
       - name: deploy to firebase
         uses: w9jds/firebase-action@v14.10.1
         with:
-          args: deploy
+          args: deploy --force
         env:
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY_DEV }}
           PROJECT_ID: dev

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -56,7 +56,7 @@ jobs:
       - name: deploy to firebase
         uses: w9jds/firebase-action@v14.10.1
         with:
-          args: deploy
+          args: deploy --force
         env:
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY_PROD }}
           PROJECT_ID: prod


### PR DESCRIPTION
## Summary
deploy ジョブが「Could not set up cleanup policy ... Pass the --force option」で exit 1 になっていた問題の修正。関数自体はすべて正常にデプロイされていたが、Artifact Registry のクリーンアップポリシー初期設定が対話入力を待つため CI で失敗扱いになる。

## Changes
- `dev.yml` / `prod.yml` の firebase-action の args を `deploy` → `deploy --force` に変更

## Test plan
- [ ] dev ワークフローが緑

🤖 Generated with [Claude Code](https://claude.com/claude-code)