### PR TITLE
chore(build): switch to application builder

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -25,11 +25,14 @@
       "prefix": "app",
       "architect": {
         "build": {
-          "builder": "@angular-devkit/build-angular:browser",
+          "builder": "@angular-devkit/build-angular:application",
           "options": {
-            "outputPath": "dist/musil",
+            "outputPath": {
+              "base": "dist/musil",
+              "browser": ""
+            },
             "index": "src/index.html",
-            "main": "src/main.ts",
+            "browser": "src/main.ts",
             "polyfills": ["zone.js"],
             "tsConfig": "tsconfig.app.json",
             "inlineStyleLanguage": "scss",
@@ -75,12 +78,9 @@
               "outputHashing": "all"
             },
             "development": {
-              "buildOptimizer": false,
               "optimization": false,
-              "vendorChunk": true,
               "extractLicenses": false,
-              "sourceMap": true,
-              "namedChunks": true
+              "sourceMap": true
             }
           },
           "defaultConfiguration": "development"


### PR DESCRIPTION
## Summary
Angular のビルダーを webpack ベースの `:browser` から esbuild ベースの `:application` に切り替え。Angular 17+ の推奨ビルダー。

## Changes
- `angular.json`:
  - `builder`: `@angular-devkit/build-angular:browser` → `@angular-devkit/build-angular:application`
  - `options.main` → `options.browser`
  - `outputPath`: `"dist/musil"` → `{ "base": "dist/musil", "browser": "" }`（既存の postbuild スクリプトと SSR Function `render` の互換性維持のため、`dist/musil/` 直下に出力）
  - development configuration から `vendorChunk` / `buildOptimizer` / `namedChunks` を削除（application builder 非対応）

## Test plan
- [x] `pnpm build` (development) 成功、`dist/musil/index.html` が生成される
- [x] `pnpm test` (81/81 緑)
- [ ] dev ワークフロー (production build) が緑
- [ ] デプロイ後の SSR (`/a/**`) が動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)