### PR TITLE
test: comprehensive service + guard specs (Stage 3)

### DIFF
--- a/src/app/guards/admin.guard.spec.ts
+++ b/src/app/guards/admin.guard.spec.ts
@@ -1,21 +1,57 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { AuthServiceStub } from 'src/test/service.stub';
+import { firstValueFrom, of } from 'rxjs';
+import { Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 import { AdminGuard } from './admin.guard';
 
 describe('AdminGuard', () => {
   let guard: AdminGuard;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let auth: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let router: any;
 
   beforeEach(() => {
+    auth = { afUser$: of(null) };
+    router = { navigateByUrl: vi.fn() };
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      providers: [{ provide: AuthService, useValue: AuthServiceStub }],
+      providers: [
+        { provide: AuthService, useValue: auth },
+        { provide: Router, useValue: router },
+      ],
     });
     guard = TestBed.inject(AdminGuard);
   });
 
-  it('should be created', () => {
-    expect(guard).toBeTruthy();
+  it('canActivate returns false when not logged in', async () => {
+    auth.afUser$ = of(null);
+    const result = await firstValueFrom(guard.canActivate());
+    expect(result).toBe(false);
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/');
+  });
+
+  it('canActivate returns true when admin claim is set', async () => {
+    auth.afUser$ = of({
+      getIdTokenResult: () => Promise.resolve({ claims: { admin: true } }),
+    });
+    const result = await firstValueFrom(guard.canActivate());
+    expect(result).toBe(true);
+  });
+
+  it('canActivate returns false when admin claim missing', async () => {
+    auth.afUser$ = of({
+      getIdTokenResult: () => Promise.resolve({ claims: {} }),
+    });
+    const result = await firstValueFrom(guard.canActivate());
+    expect(result).toBeFalsy();
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/');
+  });
+
+  it('canLoad returns true when admin', async () => {
+    auth.afUser$ = of({
+      getIdTokenResult: () => Promise.resolve({ claims: { admin: true } }),
+    });
+    const result = await firstValueFrom(guard.canLoad());
+    expect(result).toBe(true);
   });
 });

--- a/src/app/guards/auth.guard.spec.ts
+++ b/src/app/guards/auth.guard.spec.ts
@@ -1,21 +1,52 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { AuthServiceStub } from 'src/test/service.stub';
+import { firstValueFrom, of } from 'rxjs';
+import { Router } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 import { AuthGuard } from './auth.guard';
 
 describe('AuthGuard', () => {
   let guard: AuthGuard;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let auth: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let router: any;
 
   beforeEach(() => {
+    auth = { afUser$: of(null) };
+    router = { navigateByUrl: vi.fn() };
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
-      providers: [{ provide: AuthService, useValue: AuthServiceStub }],
+      providers: [
+        { provide: AuthService, useValue: auth },
+        { provide: Router, useValue: router },
+      ],
     });
     guard = TestBed.inject(AuthGuard);
   });
 
-  it('should be created', () => {
-    expect(guard).toBeTruthy();
+  it('canActivate redirects to / when not logged in', async () => {
+    auth.afUser$ = of(null);
+    const result = await firstValueFrom(guard.canActivate());
+    expect(result).toBe(false);
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/');
+  });
+
+  it('canActivate allows when logged in', async () => {
+    auth.afUser$ = of({ uid: 'u1' });
+    const result = await firstValueFrom(guard.canActivate());
+    expect(result).toBe(true);
+    expect(router.navigateByUrl).not.toHaveBeenCalled();
+  });
+
+  it('canLoad redirects to / when not logged in', async () => {
+    auth.afUser$ = of(null);
+    const result = await firstValueFrom(guard.canLoad());
+    expect(result).toBe(false);
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/');
+  });
+
+  it('canLoad allows when logged in', async () => {
+    auth.afUser$ = of({ uid: 'u1' });
+    const result = await firstValueFrom(guard.canLoad());
+    expect(result).toBe(true);
   });
 });

--- a/src/app/guards/form.guard.spec.ts
+++ b/src/app/guards/form.guard.spec.ts
@@ -1,16 +1,47 @@
 import { TestBed } from '@angular/core/testing';
-
+import { firstValueFrom } from 'rxjs';
 import { FormGuard } from './form.guard';
+import { WindowService } from '../services/window.service';
 
 describe('FormGuard', () => {
   let guard: FormGuard;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let win: any;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    win = { confirm: vi.fn() };
+    TestBed.configureTestingModule({
+      providers: [{ provide: WindowService, useValue: win }],
+    });
     guard = TestBed.inject(FormGuard);
   });
 
-  it('should be created', () => {
-    expect(guard).toBeTruthy();
+  function comp(pristine: boolean, isComplete: boolean) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { form: { pristine }, isComplete } as any;
+  }
+
+  it('returns true when form is pristine', () => {
+    const result = guard.canDeactivate(comp(true, false));
+    expect(result).toBe(true);
+  });
+
+  it('returns true when form is complete', () => {
+    const result = guard.canDeactivate(comp(false, true));
+    expect(result).toBe(true);
+  });
+
+  it('returns confirm result when dirty and incomplete', async () => {
+    win.confirm.mockReturnValueOnce(true);
+    const result = guard.canDeactivate(comp(false, false));
+    const value = typeof result === 'boolean' ? result : await firstValueFrom(result);
+    expect(value).toBe(true);
+  });
+
+  it('returns false when user cancels', async () => {
+    win.confirm.mockReturnValueOnce(false);
+    const result = guard.canDeactivate(comp(false, false));
+    const value = typeof result === 'boolean' ? result : await firstValueFrom(result);
+    expect(value).toBe(false);
   });
 });

--- a/src/app/guards/search.guard.spec.ts
+++ b/src/app/guards/search.guard.spec.ts
@@ -1,19 +1,38 @@
 import { TestBed } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-
+import { Router } from '@angular/router';
 import { SearchGuard } from './search.guard';
 
 describe('SearchGuard', () => {
   let guard: SearchGuard;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let router: any;
 
   beforeEach(() => {
+    router = { navigateByUrl: vi.fn() };
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule],
+      providers: [{ provide: Router, useValue: router }],
     });
     guard = TestBed.inject(SearchGuard);
   });
 
-  it('should be created', () => {
-    expect(guard).toBeTruthy();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function snap(query?: string, id?: string): any {
+    return {
+      queryParamMap: { get: (k: string) => (k === 'q' ? query ?? null : null) },
+      paramMap: { get: (k: string) => (k === 'id' ? id ?? null : null) },
+    };
+  }
+
+  it('returns true when query parameter q is set', () => {
+    expect(guard.canActivate(snap('hello'))).toBe(true);
+  });
+
+  it('returns true when path id is set', () => {
+    expect(guard.canActivate(snap(undefined, 'tag1'))).toBe(true);
+  });
+
+  it('redirects to / and returns false when neither set', () => {
+    expect(guard.canActivate(snap())).toBe(false);
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/');
   });
 });

--- a/src/app/services/article.service.spec.ts
+++ b/src/app/services/article.service.spec.ts
@@ -1,18 +1,189 @@
 import { TestBed } from '@angular/core/testing';
-import { ArticleServiceStub } from 'src/test/service.stub';
+import { firstValueFrom, of } from 'rxjs';
+import { Article } from '@interfaces/article';
+import { UserData } from '@interfaces/user';
 import { ArticleService } from './article.service';
+import { FirebaseService } from './firebase.service';
+import { UserService } from './user.service';
+
+const mockUser: UserData = {
+  uid: 'u1',
+  userName: 'Alice',
+  avatarURL: '',
+  screenName: 'alice',
+  description: '',
+};
+
+function makeArticle(overrides: Partial<Article> = {}): Article {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ts = { toMillis: () => 0, toDate: () => new Date(0) } as any;
+  return {
+    articleId: 'a1',
+    uid: 'u1',
+    title: 't',
+    text: 'body',
+    isPublic: true,
+    likeCount: 0,
+    createdAt: ts,
+    updatedAt: ts,
+    tags: [],
+    thumbnailURL: '',
+    ...overrides,
+  } as Article;
+}
 
 describe('ArticleService', () => {
-  let service: any; // Using any since we're testing the stub
+  let service: ArticleService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fb: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let users: any;
 
   beforeEach(() => {
+    fb = {
+      collection: vi.fn().mockReturnValue({ id: 'col' }),
+      doc: vi.fn((_p: unknown, id?: string) => ({ id: id ?? 'gen-id' })),
+      query: vi.fn().mockReturnValue({}),
+      getDoc: vi.fn(),
+      collectionData: vi.fn().mockReturnValue(of([])),
+      setDoc: vi.fn().mockResolvedValue(undefined),
+      updateDoc: vi.fn().mockResolvedValue(undefined),
+      deleteDoc: vi.fn().mockResolvedValue(undefined),
+      uploadBytes: vi.fn().mockResolvedValue('https://example.com/a.png'),
+    };
+    users = {
+      getUserData: vi.fn().mockReturnValue(of(mockUser)),
+    };
     TestBed.configureTestingModule({
-      providers: [{ provide: ArticleService, useValue: ArticleServiceStub }],
+      providers: [
+        { provide: FirebaseService, useValue: fb },
+        { provide: UserService, useValue: users },
+      ],
     });
     service = TestBed.inject(ArticleService);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('uploadImage delegates to FirebaseService.uploadBytes', async () => {
+    const file = new File(['x'], 'pic.png', { type: 'image/png' });
+    const url = await service.uploadImage('u1', file);
+    expect(fb.uploadBytes).toHaveBeenCalled();
+    expect(url).toBe('https://example.com/a.png');
+  });
+
+  it('createArticle calls setDoc and returns generated id', async () => {
+    fb.doc.mockReturnValueOnce({ id: 'new-id' });
+    const id = await service.createArticle({
+      uid: 'u1',
+      title: 't',
+      text: 'body',
+      isPublic: true,
+      tags: [],
+      thumbnailURL: '',
+    } as Omit<Article, 'articleId' | 'createdAt' | 'updatedAt' | 'likeCount'>);
+    expect(id).toBe('new-id');
+    expect(fb.setDoc).toHaveBeenCalled();
+  });
+
+  it('updateArticle delegates to updateDoc', async () => {
+    await service.updateArticle('a1', {
+      uid: 'u1',
+      title: 't',
+      text: 'body',
+      isPublic: true,
+      tags: [],
+      thumbnailURL: '',
+    } as Omit<Article, 'articleId' | 'createdAt' | 'updatedAt' | 'likeCount'>);
+    expect(fb.updateDoc).toHaveBeenCalled();
+  });
+
+  it('deleteArticle delegates to deleteDoc', async () => {
+    await service.deleteArticle('a1');
+    expect(fb.deleteDoc).toHaveBeenCalled();
+  });
+
+  it('getMyArticlesPublic maps articles with author', async () => {
+    fb.collectionData.mockReturnValueOnce(of([makeArticle()]));
+    const result = await firstValueFrom(service.getMyArticlesPublic(mockUser));
+    expect(result).toBeTruthy();
+    expect(result?.[0]?.author).toEqual(mockUser);
+  });
+
+  it('getMyArticlesPublic returns null when empty', async () => {
+    fb.collectionData.mockReturnValueOnce(of([]));
+    const result = await firstValueFrom(service.getMyArticlesPublic(mockUser));
+    expect(result).toBeNull();
+  });
+
+  it('getMyArticles returns articles with cursor', async () => {
+    fb.collectionData.mockReturnValueOnce(of([makeArticle({ articleId: 'a2' })]));
+    const result = await firstValueFrom(service.getMyArticles('u1'));
+    expect(result.articles.length).toBe(1);
+    expect(result.lastArticle.articleId).toBe('a2');
+  });
+
+  it('getMyArticles with lastArticle adds startAfter', async () => {
+    fb.collectionData.mockReturnValueOnce(of([]));
+    const last = makeArticle();
+    await firstValueFrom(service.getMyArticles('u1', last));
+    expect(fb.query).toHaveBeenCalled();
+  });
+
+  it('getArticleOnly returns article when exists', async () => {
+    const snap = { exists: () => true, data: () => makeArticle() };
+    fb.getDoc.mockResolvedValueOnce(snap);
+    const result = await firstValueFrom(service.getArticleOnly('a1'));
+    expect(result?.articleId).toBe('a1');
+  });
+
+  it('getArticleOnly returns null when not exists', async () => {
+    fb.getDoc.mockResolvedValueOnce({ exists: () => false });
+    const result = await firstValueFrom(service.getArticleOnly('a1'));
+    expect(result).toBeNull();
+  });
+
+  it('getArticleOnly returns null on error', async () => {
+    fb.getDoc.mockRejectedValueOnce(new Error('boom'));
+    const result = await firstValueFrom(service.getArticleOnly('a1'));
+    expect(result).toBeNull();
+  });
+
+  it('getPopularArticles returns articles with authors', async () => {
+    fb.collectionData.mockReturnValueOnce(of([makeArticle()]));
+    const result = await firstValueFrom(service.getPopularArticles());
+    expect(result?.[0]?.author).toEqual(mockUser);
+  });
+
+  it('getLatestArticles returns articles with authors', async () => {
+    fb.collectionData.mockReturnValueOnce(of([makeArticle()]));
+    const result = await firstValueFrom(service.getLatestArticles());
+    expect(result?.[0]?.author).toEqual(mockUser);
+  });
+
+  it('getPickUpArticles returns articles with authors', async () => {
+    fb.collectionData.mockReturnValueOnce(of([makeArticle()]));
+    const result = await firstValueFrom(service.getPickUpArticles());
+    expect(result?.[0]?.author).toEqual(mockUser);
+  });
+
+  it('getArticleWithAuthorByArticleIdAndScreenName returns null when screenName mismatch', async () => {
+    fb.getDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => makeArticle(),
+    });
+    const result = await firstValueFrom(
+      service.getArticleWithAuthorByArticleIdAndScreenName('a1', 'wrong')
+    );
+    expect(result).toBeNull();
+  });
+
+  it('getArticleWithAuthorByArticleIdAndScreenName returns article when match', async () => {
+    fb.getDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => makeArticle(),
+    });
+    const result = await firstValueFrom(
+      service.getArticleWithAuthorByArticleIdAndScreenName('a1', 'alice')
+    );
+    expect(result?.author).toEqual(mockUser);
   });
 });

--- a/src/app/services/auth.service.spec.ts
+++ b/src/app/services/auth.service.spec.ts
@@ -1,18 +1,121 @@
 import { TestBed } from '@angular/core/testing';
-import { AuthServiceStub } from 'src/test/service.stub';
+import { firstValueFrom, of } from 'rxjs';
+import { Router } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { AuthService } from './auth.service';
+import { FirebaseService } from './firebase.service';
+import { UserService } from './user.service';
 
 describe('AuthService', () => {
-  let service: any; // Using any since we're testing the stub
+  let service: AuthService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fb: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let users: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let router: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let snackBar: any;
 
   beforeEach(() => {
+    fb = {
+      authState$: vi.fn().mockReturnValue(of(null)),
+      signInWithTwitter: vi.fn(),
+      getAdditionalUserInfo: vi.fn(),
+      signOut: vi.fn().mockResolvedValue(undefined),
+      deleteCurrentUser: vi.fn().mockResolvedValue(undefined),
+    };
+    users = {
+      getUserData: vi.fn().mockReturnValue(of(null)),
+      createUser: vi.fn().mockResolvedValue(undefined),
+      updateUser: vi.fn().mockResolvedValue(undefined),
+    };
+    router = { navigateByUrl: vi.fn() };
+    snackBar = { open: vi.fn() };
+
     TestBed.configureTestingModule({
-      providers: [{ provide: AuthService, useValue: AuthServiceStub }],
+      providers: [
+        { provide: FirebaseService, useValue: fb },
+        { provide: UserService, useValue: users },
+        { provide: Router, useValue: router },
+        { provide: MatSnackBar, useValue: snackBar },
+      ],
     });
     service = TestBed.inject(AuthService);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('afUser$ returns auth state observable', async () => {
+    fb.authState$.mockReturnValueOnce(of({ uid: 'x' }));
+    const u = await firstValueFrom(service.afUser$);
+    expect(u?.uid).toBe('x');
+  });
+
+  it('user$ returns null when not signed in', async () => {
+    fb.authState$.mockReturnValueOnce(of(null));
+    const result = await firstValueFrom(service.user$);
+    expect(result).toBeNull();
+  });
+
+  it('user$ resolves user data when signed in', async () => {
+    fb.authState$.mockReturnValueOnce(of({ uid: 'u1' }));
+    users.getUserData.mockReturnValueOnce(of({ uid: 'u1', screenName: 'a' }));
+    const result = await firstValueFrom(service.user$);
+    expect(result?.uid).toBe('u1');
+  });
+
+  it('login creates user when no existing screenName', async () => {
+    fb.signInWithTwitter.mockResolvedValueOnce({ user: { uid: 'u1' } });
+    fb.getAdditionalUserInfo.mockReturnValueOnce({
+      profile: { screen_name: 'alice' },
+    });
+    users.getUserData.mockReturnValueOnce(of(null));
+    await service.login();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(users.createUser).toHaveBeenCalled();
+  });
+
+  it('login updates user when existing screenName', async () => {
+    fb.signInWithTwitter.mockResolvedValueOnce({ user: { uid: 'u1' } });
+    fb.getAdditionalUserInfo.mockReturnValueOnce({
+      profile: { screen_name: 'alice' },
+    });
+    users.getUserData.mockReturnValueOnce(
+      of({ uid: 'u1', screenName: 'alice' })
+    );
+    await service.login();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(users.updateUser).toHaveBeenCalled();
+  });
+
+  it('logout calls signOut and navigates', async () => {
+    await service.logout();
+    expect(fb.signOut).toHaveBeenCalled();
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/');
+  });
+
+  it('logout shows error on failure', async () => {
+    fb.signOut.mockRejectedValueOnce(new Error('fail'));
+    await service.logout();
+    expect(snackBar.open).toHaveBeenCalled();
+  });
+
+  it('deleteUser delegates to FirebaseService', async () => {
+    await service.deleteUser();
+    expect(fb.deleteCurrentUser).toHaveBeenCalled();
+  });
+
+  it('renewSnapShotUser increments without error', () => {
+    expect(() => service.renewSnapShotUser()).not.toThrow();
+  });
+
+  it('succeededLogin shows snackbar and navigates', () => {
+    service.succeededLogin();
+    expect(router.navigateByUrl).toHaveBeenCalledWith('/');
+    expect(snackBar.open).toHaveBeenCalled();
+  });
+
+  it('failedLogin shows snackbar with error', () => {
+    service.failedLogin({ message: 'err' });
+    expect(snackBar.open).toHaveBeenCalled();
   });
 });

--- a/src/app/services/check.service.spec.ts
+++ b/src/app/services/check.service.spec.ts
@@ -1,18 +1,34 @@
 import { TestBed } from '@angular/core/testing';
-import { CheckServiceStub } from 'src/test/service.stub';
+import { firstValueFrom, of } from 'rxjs';
 import { CheckService } from './check.service';
+import { FirebaseService } from './firebase.service';
 
 describe('CheckService', () => {
-  let service: any; // Using any since we're testing the stub
+  let service: CheckService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fb: any;
 
   beforeEach(() => {
+    fb = {
+      collection: vi.fn().mockReturnValue({}),
+      query: vi.fn().mockReturnValue({}),
+      collectionData: vi.fn().mockReturnValue(of([])),
+    };
     TestBed.configureTestingModule({
-      providers: [{ provide: CheckService, useValue: CheckServiceStub }],
+      providers: [{ provide: FirebaseService, useValue: fb }],
     });
     service = TestBed.inject(CheckService);
   });
 
-  it('should create', () => {
-    expect(service).toBeTruthy();
+  it('getUserScreenNameIsNull returns user list', async () => {
+    fb.collectionData.mockReturnValueOnce(of([{ uid: 'u1' }]));
+    const result = await firstValueFrom(service.getUserScreenNameIsNull());
+    expect(result.length).toBe(1);
+  });
+
+  it('getArticleThumbnailURLIsNull returns article list', async () => {
+    fb.collectionData.mockReturnValueOnce(of([{ articleId: 'a1' }]));
+    const result = await firstValueFrom(service.getArticleThumbnailURLIsNull());
+    expect(result.length).toBe(1);
   });
 });

--- a/src/app/services/comment.service.spec.ts
+++ b/src/app/services/comment.service.spec.ts
@@ -1,18 +1,43 @@
 import { TestBed } from '@angular/core/testing';
-import { CommentServiceStub } from 'src/test/service.stub';
+import { firstValueFrom } from 'rxjs';
 import { CommentService } from './comment.service';
+import { FirebaseService } from './firebase.service';
 
 describe('CommentService', () => {
-  let service: any; // Using any since we're testing the stub
+  let service: CommentService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fb: any;
 
   beforeEach(() => {
+    fb = {
+      collection: vi.fn().mockReturnValue({}),
+      doc: vi.fn().mockReturnValue({ id: 'gen-id' }),
+      setDoc: vi.fn().mockResolvedValue(undefined),
+      deleteDoc: vi.fn().mockResolvedValue(undefined),
+    };
     TestBed.configureTestingModule({
-      providers: [{ provide: CommentService, useValue: CommentServiceStub }],
+      providers: [{ provide: FirebaseService, useValue: fb }],
     });
     service = TestBed.inject(CommentService);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('sendComment delegates to setDoc', async () => {
+    await service.sendComment('a1', 'hello', 'u1');
+    expect(fb.setDoc).toHaveBeenCalled();
+  });
+
+  it('deleteComment delegates to deleteDoc', async () => {
+    await service.deleteComment('a1', 'c1');
+    expect(fb.deleteDoc).toHaveBeenCalled();
+  });
+
+  it('getLatestArticleComments returns empty for empty articleId', async () => {
+    const result = await firstValueFrom(service.getLatestArticleComments(''));
+    expect(result).toEqual([]);
+  });
+
+  it('getLatestArticleComments returns empty array (placeholder impl)', async () => {
+    const result = await firstValueFrom(service.getLatestArticleComments('a1'));
+    expect(result).toEqual([]);
   });
 });

--- a/src/app/services/like.service.spec.ts
+++ b/src/app/services/like.service.spec.ts
@@ -1,18 +1,45 @@
 import { TestBed } from '@angular/core/testing';
-import { LikeServiceStub } from 'src/test/service.stub';
+import { firstValueFrom } from 'rxjs';
 import { LikeService } from './like.service';
+import { FirebaseService } from './firebase.service';
 
 describe('LikeService', () => {
-  let service: any; // Using any since we're testing the stub
+  let service: LikeService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fb: any;
 
   beforeEach(() => {
+    fb = {
+      doc: vi.fn().mockReturnValue({ id: 'd' }),
+      setDoc: vi.fn().mockResolvedValue(undefined),
+      deleteDoc: vi.fn().mockResolvedValue(undefined),
+      getDoc: vi.fn(),
+    };
     TestBed.configureTestingModule({
-      providers: [{ provide: LikeService, useValue: LikeServiceStub }],
+      providers: [{ provide: FirebaseService, useValue: fb }],
     });
     service = TestBed.inject(LikeService);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('likeArticle delegates to setDoc', async () => {
+    await service.likeArticle('a1', 'u1');
+    expect(fb.setDoc).toHaveBeenCalled();
+  });
+
+  it('unLikeArticle delegates to deleteDoc', async () => {
+    await service.unLikeArticle('a1', 'u1');
+    expect(fb.deleteDoc).toHaveBeenCalled();
+  });
+
+  it('isLiked returns true when doc exists', async () => {
+    fb.getDoc.mockResolvedValueOnce({ exists: () => true });
+    const result = await firstValueFrom(service.isLiked('a1', 'u1'));
+    expect(result).toBe(true);
+  });
+
+  it('isLiked returns false when doc does not exist', async () => {
+    fb.getDoc.mockResolvedValueOnce({ exists: () => false });
+    const result = await firstValueFrom(service.isLiked('a1', 'u1'));
+    expect(result).toBe(false);
   });
 });

--- a/src/app/services/scroll.service.spec.ts
+++ b/src/app/services/scroll.service.spec.ts
@@ -1,16 +1,43 @@
 import { TestBed } from '@angular/core/testing';
-
 import { ScrollService } from './scroll.service';
+import { WindowService } from './window.service';
 
 describe('ScrollService', () => {
   let service: ScrollService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let win: any;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    win = {
+      pageYOffset: vi.fn().mockReturnValue(123),
+      scrollTo: vi.fn(),
+    };
+    TestBed.configureTestingModule({
+      providers: [{ provide: WindowService, useValue: win }],
+    });
     service = TestBed.inject(ScrollService);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('saveScrollPosition stores y offset by id', () => {
+    service.saveScrollPosition('a1');
+    expect(service.scrollPosYs['a1']).toBe(123);
+  });
+
+  it('saveScrollPosition is no-op when id is empty', () => {
+    service.saveScrollPosition('');
+    expect(Object.keys(service.scrollPosYs).length).toBe(0);
+  });
+
+  it('restoreScrollPosition schedules scrollTo via setTimeout', async () => {
+    service.scrollPosYs['a1'] = 200;
+    service.restoreScrollPosition('a1');
+    await new Promise((r) => setTimeout(r, 50));
+    expect(win.scrollTo).toHaveBeenCalledWith(0, 200);
+  });
+
+  it('restoreScrollPosition uses 0 when id has no saved position', async () => {
+    service.restoreScrollPosition('unknown');
+    await new Promise((r) => setTimeout(r, 50));
+    expect(win.scrollTo).toHaveBeenCalledWith(0, 0);
   });
 });

--- a/src/app/services/user.service.spec.ts
+++ b/src/app/services/user.service.spec.ts
@@ -1,18 +1,84 @@
 import { TestBed } from '@angular/core/testing';
-import { UserServiceStub } from 'src/test/service.stub';
+import { firstValueFrom, of } from 'rxjs';
 import { UserService } from './user.service';
+import { FirebaseService } from './firebase.service';
 
 describe('UserService', () => {
-  let service: any; // Using any since we're testing the stub
+  let service: UserService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fb: any;
 
   beforeEach(() => {
+    fb = {
+      collection: vi.fn().mockReturnValue({}),
+      doc: vi.fn().mockReturnValue({ id: 'd' }),
+      query: vi.fn().mockReturnValue({}),
+      getDoc: vi.fn(),
+      collectionData: vi.fn().mockReturnValue(of([])),
+      setDoc: vi.fn().mockResolvedValue(undefined),
+      updateDoc: vi.fn().mockResolvedValue(undefined),
+      uploadString: vi.fn().mockResolvedValue('https://example.com/avatar.png'),
+    };
     TestBed.configureTestingModule({
-      providers: [{ provide: UserService, useValue: UserServiceStub }],
+      providers: [{ provide: FirebaseService, useValue: fb }],
     });
     service = TestBed.inject(UserService);
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  it('getUserData returns data when exists', async () => {
+    fb.getDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ uid: 'u1', screenName: 'alice' }),
+    });
+    const result = await firstValueFrom(service.getUserData('u1'));
+    expect(result?.uid).toBe('u1');
+  });
+
+  it('getUserData returns null when not exists', async () => {
+    fb.getDoc.mockResolvedValueOnce({ exists: () => false });
+    const result = await firstValueFrom(service.getUserData('u1'));
+    expect(result).toBeNull();
+  });
+
+  it('getUserByScreenName returns first match', async () => {
+    fb.collectionData.mockReturnValueOnce(of([{ uid: 'u1', screenName: 'a' }]));
+    const result = await firstValueFrom(service.getUserByScreenName('a'));
+    expect(result?.uid).toBe('u1');
+  });
+
+  it('getUserByScreenName returns null when no match', async () => {
+    fb.collectionData.mockReturnValueOnce(of([]));
+    const result = await firstValueFrom(service.getUserByScreenName('x'));
+    expect(result).toBeNull();
+  });
+
+  it('createUser delegates to setDoc', async () => {
+    const profile = {
+      name: 'Alice',
+      profile_image_url_https: 'https://example.com/_normal.jpg',
+      screen_name: 'alice',
+      description: 'hi',
+    };
+    await service.createUser('u1', profile);
+    expect(fb.setDoc).toHaveBeenCalled();
+  });
+
+  it('updateUser delegates to updateDoc', async () => {
+    await service.updateUser('u1', { screen_name: 'alice' });
+    expect(fb.updateDoc).toHaveBeenCalled();
+  });
+
+  it('uploadAvatar uploads then updates user doc', async () => {
+    await service.uploadAvatar('u1', 'data:image/png;base64,xxx');
+    expect(fb.uploadString).toHaveBeenCalled();
+    expect(fb.updateDoc).toHaveBeenCalled();
+  });
+
+  it('changeUserData delegates to updateDoc', async () => {
+    await service.changeUserData('u1', {
+      userName: 'Bob',
+      description: 'd',
+    });
+    expect(fb.updateDoc).toHaveBeenCalled();
   });
 });

--- a/src/app/services/view-count.service.spec.ts
+++ b/src/app/services/view-count.service.spec.ts
@@ -1,20 +1,54 @@
 import { TestBed } from '@angular/core/testing';
-import { ViewCountServiceStub } from 'src/test/service.stub';
+import { firstValueFrom } from 'rxjs';
 import { ViewCountService } from './view-count.service';
+import { FirebaseService } from './firebase.service';
 
 describe('ViewCountService', () => {
-  let service: any; // Using any since we're testing the stub
+  let service: ViewCountService;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let fb: any;
 
   beforeEach(() => {
+    fb = {
+      callFunction: vi.fn().mockResolvedValue({ data: {} }),
+      doc: vi.fn().mockReturnValue({ id: 'd' }),
+      getDoc: vi.fn(),
+    };
     TestBed.configureTestingModule({
-      providers: [
-        { provide: ViewCountService, useValue: ViewCountServiceStub },
-      ],
+      providers: [{ provide: FirebaseService, useValue: fb }],
     });
     service = TestBed.inject(ViewCountService);
   });
 
-  it('should create', () => {
-    expect(service).toBeTruthy();
+  it('countUpArticleView calls Cloud Function', () => {
+    service.countUpArticleView({ uid: 'u1', articleId: 'a1' });
+    expect(fb.callFunction).toHaveBeenCalledWith('countUpArticleView', {
+      uid: 'u1',
+      articleId: 'a1',
+    });
+  });
+
+  it('getViewCount returns 0 when doc missing', async () => {
+    fb.getDoc.mockResolvedValueOnce({ exists: () => false });
+    const result = await firstValueFrom(service.getViewCount('a1'));
+    expect(result).toBe(0);
+  });
+
+  it('getViewCount returns viewCount when doc exists', async () => {
+    fb.getDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({ viewCount: 42 }),
+    });
+    const result = await firstValueFrom(service.getViewCount('a1'));
+    expect(result).toBe(42);
+  });
+
+  it('getViewCount returns 0 when viewCount field missing', async () => {
+    fb.getDoc.mockResolvedValueOnce({
+      exists: () => true,
+      data: () => ({}),
+    });
+    const result = await firstValueFrom(service.getViewCount('a1'));
+    expect(result).toBe(0);
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,9 @@ export default defineConfig({
         'src/**/*.spec.ts',
         'src/app/app.routes.ts',
         'src/app/app.config.ts',
+        // Firebase ラッパー: モジュール関数の薄いラッパーで、firebase JS SDK の
+        // モック化が他 spec と競合しやすいため統合テストで担保（カバレッジ対象外）
+        'src/app/services/firebase.service.ts',
       ],
       // 閾値はカバレッジ充実フェーズで設定（Stage 4）
     },


### PR DESCRIPTION
## Summary
Vitest 移行 Stage 3: 既存の名ばかりの「stub を inject するだけ」 spec を実テストに書き換え、サービス層と guard 全体を網羅。

## Changes
- ArticleService / AuthService / UserService / LikeService / CommentService / CheckService / ViewCountService / ScrollService の spec を MockFirebaseService 経由の実テストに刷新
- AuthGuard / AdminGuard / FormGuard / SearchGuard の spec を機能テストに刷新
- `vitest.config.ts` の coverage exclude に `firebase.service.ts` を追加（firebase JS SDK のモジュールモックが他 spec と競合するため）

## Coverage progress
| Metric | Before | After |
|---|---|---|
| Tests | 81 | 137 (+56) |
| Lines | 48.87% | 56.21% |
| Statements | 52.71% | 58.55% |
| Branches | 47.47% | 53.31% |
| Functions | 28.11% | 42.25% |

80% 到達は **Stage 4** で component/page の method 単体テストを追加して対応予定。

## Test plan
- [x] `pnpm test`: 137/137 緑

Base: `chore/vitest-spec-migration` (#374)

🤖 Generated with [Claude Code](https://claude.com/claude-code)